### PR TITLE
Fix bug with extensionless artifacts

### DIFF
--- a/src/TeamCitySharp/ActionTypes/BuildArtifacts.cs
+++ b/src/TeamCitySharp/ActionTypes/BuildArtifacts.cs
@@ -81,7 +81,7 @@ namespace TeamCitySharp.ActionTypes
         var artifact = string.Empty;
         if (nameNode != null)
           artifact = nameNode.Value;
-        if (extensionNode != null)
+        if (extensionNode != null && !string.IsNullOrWhiteSpace(extensionNode.Value))
           artifact += "." + extensionNode.Value;
         list.Add($"/repository/download/{m_buildConfigId}/{buildSpecification}/{artifact}");
       }


### PR DESCRIPTION
Downloading artifacts that don't have an extension was failing with a 404.