### PR TITLE
Add CODEOWNERS for team-build-foundations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @OctopusDeploy/team-build-foundations


### PR DESCRIPTION
## Add CODEOWNERS

This PR adds a CODEOWNERS file assigning ownership to \.

No functional change — this establishes team ownership for the repository.