### PR TITLE
[BLD-2830] Add 3-day cooldown to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,6 @@ updates:
     ignore:
       # FluentAssertions v8 changes the licensing in a way that cost lots, only allow v7.x
       - dependency-name: "FluentAssertions"
-        versions: [ ">=8.0.0" ] 
+        versions: [ ">=8.0.0" ]
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Adds `cooldown: default-days: 3` to each entry in `.github/dependabot.yml` so Dependabot waits 3 days after a release before opening an update PR. Gives time to catch broken releases before they propagate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)