### PR TITLE
Dry-run Renovate on pull requests, keep dots out of branch names, bump OctoVersion

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -28,3 +28,6 @@ jobs:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           LOG_LEVEL: ${{ github.ref_name == 'main' && 'INFO' || 'DEBUG' }}
           RENOVATE_BASE_BRANCHES: main
+          # A pull request run reads its config from the branch but still targets the
+          # real repository, so it must not create, update or close branches and PRs.
+          RENOVATE_DRY_RUN: ${{ github.event_name == 'pull_request' && 'full' || '' }}

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[1.0.12]" />
+    <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[1.1.48]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "{{datasource}}"
   ],
   "rebaseWhen": "conflicted",
+  "branchNameStrict": true,
   "assigneesFromCodeOwners": true,
   "prConcurrentLimit": 1,
   "minimumReleaseAge": "3 days",


### PR DESCRIPTION
Our `renovate.yaml` runs on `pull_request` when the Renovate config changes, and reads that config from the PR branch while still pointing at the real repository with a real token. An unmerged config is applied for real rather than validated. On Slipway this silently autoclosed two dependency PRs, and with `prConcurrentLimit` at 1 holding the slot, one update was left with no open PR at all.

`RENOVATE_DRY_RUN` is set only for `pull_request` runs. Renovate's env parser skips empty values, so scheduled and push runs keep writing as before, and `dryRun: full` still runs the whole extract-and-lookup pipeline, so a broken config still surfaces on the PR.

`branchNameStrict` keeps dots out of Renovate's branch names. OctoVersion truncates the branch-derived NuGet pre-release tag to 20 characters without regard for SemVer identifier boundaries; when the cut lands on a dot, the version ends in an empty identifier and `dotnet pack` rejects it.

The pinned `Octopus.OctoVersion.Tool` predates the fix for that truncation ([OctoVersion#331](https://github.com/OctopusDeploy/OctoVersion/pull/331)) and moves to 1.1.48, which ships net8.0, net9.0 and net10.0 tool assets.

Both changes land together on purpose. `branchNameStrict` alone would have this PR's own Renovate run rename branches against the live repository, which is the exact failure this is meant to prevent.

Linear: [DPT-3109](https://linear.app/octopus/issue/DPT-3109/dry-run-renovate-on-pull-requests-across-all-team-builds-repos), [DPT-3106](https://linear.app/octopus/issue/DPT-3106/octoversion-emits-an-invalid-version-when-the-nuget-pre-release-tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)